### PR TITLE
fix: various unthemed elements

### DIFF
--- a/templates/main.tera
+++ b/templates/main.tera
@@ -181,6 +181,17 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
     background: var(--crust);
   }
 
+  /* Input Box */
+  input[type='number'] {
+    color: var(--text);
+  }
+
+  /* Tooltips */
+  .q-tooltip {
+    background-color: var(--base);
+    color: var(--text);
+  }
+
   [sfc-name='HeaderSearch'] {
     .search-box {
       background: var(--mantle);

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -756,6 +756,19 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
     }
   }
 
+  /* Multi Artist Picker */
+  .artist-picker-modal {
+    background-color: var(--base);
+
+    [sfc-name='QItemSection'], .modal-titlebar-content, .close {
+      color: var(--text);
+    }
+
+    .q-item-type+.q-item-type {
+      border-top-color: var(--surface0);
+    }
+  }
+
   /* Modes */
 
   /* Miniplayer */

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -1018,5 +1018,9 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
       background-color: var(--mantle);
       color: var(--text);
     }
+
+    [sfc-name='QBadge'] {
+      color: var(--crust);
+    }
   }
 }

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -517,6 +517,37 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
     }
   }
 
+  /* General Popups using QCard */
+  [role='dialog'] [sfc-name='QCard'] {
+    background-color: var(--base);
+    color: var(--text);
+
+    .close {
+      color: var(--text);
+    }
+
+    .q-field__control {
+      background: var(--crust);
+      border-color: var(--selection-bg);
+
+      .q-field__native {
+        color: var(--text);
+      }
+
+      .q-field__label {
+        color: var(--subtext1);
+      }
+    }
+
+    .q-field__counter {
+      color: var(--subtext1);
+    }
+
+    .q-btn.bg-primary, .q-btn.bg-primary [sfc-name='QIcon'] {
+      color: var(--crust);
+    }
+  }
+
   [sfc-name='QDialog'] {
     .titlebar-button.close {
       color: var(--text);
@@ -723,7 +754,7 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
     .am-audio-settings {
       background: var(--base);
 
-      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'] {
+      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'], .close {
         color: var(--text);
       }
 

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -188,7 +188,7 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
 
   /* Tooltips */
   .q-tooltip {
-    background-color: var(--base);
+    background-color: var(--mantle);
     color: var(--text);
   }
 
@@ -454,7 +454,7 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
     }
 
     [sfc-name='QTabs'] {
-      background: var(--base);
+      background-color: var(--base);
 
       .q-tab {
         color: var(--text);
@@ -465,7 +465,7 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
       }
 
       .q-tab__indicator {
-        background: var(--selection-bg);
+        background-color: var(--selection-bg);
       }
     }
   }
@@ -474,10 +474,10 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
 
   /* Menu & Pop-ups */
   .q-menu {
-    background: var(--base);
+    background-color: var(--mantle);
 
     .q-hoverable:hover {
-      background: var(--selection-bg);
+      background-color: var(--selection-bg);
     }
 
     [sfc-name='ContextMenuIcon'],
@@ -605,7 +605,11 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
       .themes-page {
         [sfc-name='QList'] [sfc-name='QBtn'].q-btn--actionable {
           background-color: transparent;
-          color: var(--text);
+          color: var(--accent);
+        }
+
+        [sfc-name='QExpansionItem'] [sfc-name='QList'] {
+          background-color: var(--mantle);
         }
       }
     }

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -601,6 +601,13 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
       [sfc-name='QCard'] {
         color: var(--text);
       }
+
+      .themes-page {
+        [sfc-name='QList'] [sfc-name='QBtn'].q-btn--actionable {
+          background-color: transparent;
+          color: var(--text);
+        }
+      }
     }
     /* Updates Window */
     .updates-window {

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -876,6 +876,12 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
     background: var(--base);
   }
 
+  .im-window-controls {
+    .close {
+      color: var(--text);
+    }
+  }
+
   .immersive-player {
     [sfc-name='AMPMetadataMojave'] {
       .song-name {

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -381,6 +381,16 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
     .sidebar-label {
       opacity: 1;
     }
+
+    [sfc-name='QTabs'] {
+      background-color: var(--mantle);
+    }
+
+    [sfc-name='PageTabList'] {
+      .title-text {
+        color: var(--text);
+      }
+    }
   }
 
   /* Right Drawer / Queue / Lyrics */

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -247,7 +247,7 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
         color: var(--text);
       }
 
-      .albumLink, .time {
+      .albumLink, .time, .trackNumber {
         color: var(--subtext1);
       }
 

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -369,11 +369,7 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
       background: var(--selection-bg);
       color: var(--text);
 
-      .nav-icon {
-        color: var(--accent);
-      }
-
-      .nav-text {
+      .nav-icon, .nav-text {
         color: var(--accent);
       }
     }

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -518,7 +518,7 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
     background-color: var(--base);
     color: var(--text);
 
-    .close, [sfc-name='QItem'], .q-btn__content {
+    .close, [sfc-name='QItem'], [sfc-name='QBtn']:not(.bg-red, .bg-primary).q-btn__content {
       color: var(--text);
     }
 

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -488,6 +488,10 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
       }
     }
 
+    .q-btn.bg-primary, .q-btn.bg-primary [sfc-name='QIcon'] {
+      color: var(--crust);
+    }
+
     [sfc-name='QItemSection'] {
       color: var(--text);
 

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -701,6 +701,25 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
 
     .am-audio-settings {
       background: var(--base);
+
+      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'] {
+        color: var(--text);
+      }
+
+      [sfc-name='AMEQ'] {
+        .mini, .close {
+          color: var(--text);
+        }
+
+        .eq-freq, .eq-q {
+          background-color: var(--mantle);
+          color: var(--text);
+        }
+
+        [sfc-name='QBtn'] {
+          color: var(--crust);
+        }
+      }
     }
   }
 

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -45,7 +45,15 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
     background-color: var(--green);
   }
 
+  .bg-red {
+    background-color: var(--red);
+  }
+
   .text-default {
+    color: var(--text);
+  }
+
+  .text-white {
     color: var(--text);
   }
 

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -728,7 +728,7 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
       }
 
       [sfc-name='AMEQ'] {
-        .mini, .close {
+        .mini {
           color: var(--text);
         }
 

--- a/templates/main.tera
+++ b/templates/main.tera
@@ -522,7 +522,7 @@ body.body--{{ if(cond=flavor.dark, t="dark", f="light") }} {
     background-color: var(--base);
     color: var(--text);
 
-    .close {
+    .close, [sfc-name='QItem'], .q-btn__content {
       color: var(--text);
     }
 

--- a/templates/theme.tera
+++ b/templates/theme.tera
@@ -11,45 +11,7 @@ stylesheets:
   - name: Catppuccin {{ flavor.name }} - Base
     file: catppuccin-{{ flavor.identifier }}.scss
     description: Enable your favorite accent below!
-
-  - name: Rosewater
-    file: catppuccin-accent-rosewater.scss
-
-  - name: Flamingo
-    file: catppuccin-accent-flamingo.scss
-
-  - name: Pink
-    file: catppuccin-accent-pink.scss
-
-  - name: Mauve
-    file: catppuccin-accent-mauve.scss
-
-  - name: Red
-    file: catppuccin-accent-red.scss
-
-  - name: Maroon
-    file: catppuccin-accent-maroon.scss
-
-  - name: Peach
-    file: catppuccin-accent-peach.scss
-
-  - name: Yellow
-    file: catppuccin-accent-yellow.scss
-
-  - name: Green
-    file: catppuccin-accent-green.scss
-
-  - name: Teal
-    file: catppuccin-accent-teal.scss
-
-  - name: Sky
-    file: catppuccin-accent-sky.scss
-
-  - name: Sapphire
-    file: catppuccin-accent-sapphire.scss
-
-  - name: Blue
-    file: catppuccin-accent-blue.scss
-
-  - name: Lavender
-    file: catppuccin-accent-lavender.scss
+  {% for identifier, color in flavor.colors %}{% if color.accent %}
+  - name: {{ color.name }}
+    file: catppuccin-accent-{{ identifier }}.scss
+  {% endif %}{% endfor %}

--- a/themes/ctp-frappe/catppuccin-frappe.scss
+++ b/themes/ctp-frappe/catppuccin-frappe.scss
@@ -515,7 +515,7 @@ body.body--dark {
     background-color: var(--base);
     color: var(--text);
 
-    .close {
+    .close, [sfc-name='QItem'], .q-btn__content {
       color: var(--text);
     }
 

--- a/themes/ctp-frappe/catppuccin-frappe.scss
+++ b/themes/ctp-frappe/catppuccin-frappe.scss
@@ -362,11 +362,7 @@ body.body--dark {
       background: var(--selection-bg);
       color: var(--text);
 
-      .nav-icon {
-        color: var(--accent);
-      }
-
-      .nav-text {
+      .nav-icon, .nav-text {
         color: var(--accent);
       }
     }

--- a/themes/ctp-frappe/catppuccin-frappe.scss
+++ b/themes/ctp-frappe/catppuccin-frappe.scss
@@ -1011,5 +1011,9 @@ body.body--dark {
       background-color: var(--mantle);
       color: var(--text);
     }
+
+    [sfc-name='QBadge'] {
+      color: var(--crust);
+    }
   }
 }

--- a/themes/ctp-frappe/catppuccin-frappe.scss
+++ b/themes/ctp-frappe/catppuccin-frappe.scss
@@ -511,7 +511,7 @@ body.body--dark {
     background-color: var(--base);
     color: var(--text);
 
-    .close, [sfc-name='QItem'], .q-btn__content {
+    .close, [sfc-name='QItem'], [sfc-name='QBtn']:not(.bg-red, .bg-primary).q-btn__content {
       color: var(--text);
     }
 
@@ -867,6 +867,12 @@ body.body--dark {
   /* Immersive Browser Toolbar */
   .im-toolbar {
     background: var(--base);
+  }
+
+  .im-window-controls {
+    .close {
+      color: var(--text);
+    }
   }
 
   .immersive-player {

--- a/themes/ctp-frappe/catppuccin-frappe.scss
+++ b/themes/ctp-frappe/catppuccin-frappe.scss
@@ -38,7 +38,15 @@ body.body--dark {
     background-color: var(--green);
   }
 
+  .bg-red {
+    background-color: var(--red);
+  }
+
   .text-default {
+    color: var(--text);
+  }
+
+  .text-white {
     color: var(--text);
   }
 
@@ -166,6 +174,17 @@ body.body--dark {
     background: var(--crust);
   }
 
+  /* Input Box */
+  input[type='number'] {
+    color: var(--text);
+  }
+
+  /* Tooltips */
+  .q-tooltip {
+    background-color: var(--base);
+    color: var(--text);
+  }
+
   [sfc-name='HeaderSearch'] {
     .search-box {
       background: var(--mantle);
@@ -221,7 +240,7 @@ body.body--dark {
         color: var(--text);
       }
 
-      .albumLink, .time {
+      .albumLink, .time, .trackNumber {
         color: var(--subtext1);
       }
 
@@ -355,6 +374,16 @@ body.body--dark {
     .sidebar-label {
       opacity: 1;
     }
+
+    [sfc-name='QTabs'] {
+      background-color: var(--mantle);
+    }
+
+    [sfc-name='PageTabList'] {
+      .title-text {
+        color: var(--text);
+      }
+    }
   }
 
   /* Right Drawer / Queue / Lyrics */
@@ -462,6 +491,10 @@ body.body--dark {
       }
     }
 
+    .q-btn.bg-primary, .q-btn.bg-primary [sfc-name='QIcon'] {
+      color: var(--crust);
+    }
+
     [sfc-name='QItemSection'] {
       color: var(--text);
 
@@ -560,6 +593,13 @@ body.body--dark {
 
       [sfc-name='QCard'] {
         color: var(--text);
+      }
+
+      .themes-page {
+        [sfc-name='QList'] [sfc-name='QBtn'].q-btn--actionable {
+          background-color: transparent;
+          color: var(--text);
+        }
       }
     }
     /* Updates Window */
@@ -671,6 +711,25 @@ body.body--dark {
 
     .am-audio-settings {
       background: var(--base);
+
+      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'] {
+        color: var(--text);
+      }
+
+      [sfc-name='AMEQ'] {
+        .mini, .close {
+          color: var(--text);
+        }
+
+        .eq-freq, .eq-q {
+          background-color: var(--mantle);
+          color: var(--text);
+        }
+
+        [sfc-name='QBtn'] {
+          color: var(--crust);
+        }
+      }
     }
   }
 
@@ -704,6 +763,19 @@ body.body--dark {
 
     button .qb-item-content {
       color: var(--crust);
+    }
+  }
+
+  /* Multi Artist Picker */
+  .artist-picker-modal {
+    background-color: var(--base);
+
+    [sfc-name='QItemSection'], .modal-titlebar-content, .close {
+      color: var(--text);
+    }
+
+    .q-item-type+.q-item-type {
+      border-top-color: var(--surface0);
     }
   }
 

--- a/themes/ctp-frappe/catppuccin-frappe.scss
+++ b/themes/ctp-frappe/catppuccin-frappe.scss
@@ -181,7 +181,7 @@ body.body--dark {
 
   /* Tooltips */
   .q-tooltip {
-    background-color: var(--base);
+    background-color: var(--mantle);
     color: var(--text);
   }
 
@@ -447,7 +447,7 @@ body.body--dark {
     }
 
     [sfc-name='QTabs'] {
-      background: var(--base);
+      background-color: var(--base);
 
       .q-tab {
         color: var(--text);
@@ -458,7 +458,7 @@ body.body--dark {
       }
 
       .q-tab__indicator {
-        background: var(--selection-bg);
+        background-color: var(--selection-bg);
       }
     }
   }
@@ -467,10 +467,10 @@ body.body--dark {
 
   /* Menu & Pop-ups */
   .q-menu {
-    background: var(--base);
+    background-color: var(--mantle);
 
     .q-hoverable:hover {
-      background: var(--selection-bg);
+      background-color: var(--selection-bg);
     }
 
     [sfc-name='ContextMenuIcon'],
@@ -507,6 +507,37 @@ body.body--dark {
       .overlay-progress-bar {
         background: var(--text);
       }
+    }
+  }
+
+  /* General Popups using QCard */
+  [role='dialog'] [sfc-name='QCard'] {
+    background-color: var(--base);
+    color: var(--text);
+
+    .close {
+      color: var(--text);
+    }
+
+    .q-field__control {
+      background: var(--crust);
+      border-color: var(--selection-bg);
+
+      .q-field__native {
+        color: var(--text);
+      }
+
+      .q-field__label {
+        color: var(--subtext1);
+      }
+    }
+
+    .q-field__counter {
+      color: var(--subtext1);
+    }
+
+    .q-btn.bg-primary, .q-btn.bg-primary [sfc-name='QIcon'] {
+      color: var(--crust);
     }
   }
 
@@ -598,7 +629,11 @@ body.body--dark {
       .themes-page {
         [sfc-name='QList'] [sfc-name='QBtn'].q-btn--actionable {
           background-color: transparent;
-          color: var(--text);
+          color: var(--accent);
+        }
+
+        [sfc-name='QExpansionItem'] [sfc-name='QList'] {
+          background-color: var(--mantle);
         }
       }
     }
@@ -712,12 +747,12 @@ body.body--dark {
     .am-audio-settings {
       background: var(--base);
 
-      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'] {
+      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'], .close {
         color: var(--text);
       }
 
       [sfc-name='AMEQ'] {
-        .mini, .close {
+        .mini {
           color: var(--text);
         }
 

--- a/themes/ctp-frappe/theme.yml
+++ b/themes/ctp-frappe/theme.yml
@@ -4,45 +4,46 @@ stylesheets:
   - name: Catppuccin Frappé - Base
     file: catppuccin-frappe.scss
     description: Enable your favorite accent below!
-
+  
   - name: Rosewater
     file: catppuccin-accent-rosewater.scss
-
+  
   - name: Flamingo
     file: catppuccin-accent-flamingo.scss
-
+  
   - name: Pink
     file: catppuccin-accent-pink.scss
-
+  
   - name: Mauve
     file: catppuccin-accent-mauve.scss
-
+  
   - name: Red
     file: catppuccin-accent-red.scss
-
+  
   - name: Maroon
     file: catppuccin-accent-maroon.scss
-
+  
   - name: Peach
     file: catppuccin-accent-peach.scss
-
+  
   - name: Yellow
     file: catppuccin-accent-yellow.scss
-
+  
   - name: Green
     file: catppuccin-accent-green.scss
-
+  
   - name: Teal
     file: catppuccin-accent-teal.scss
-
+  
   - name: Sky
     file: catppuccin-accent-sky.scss
-
+  
   - name: Sapphire
     file: catppuccin-accent-sapphire.scss
-
+  
   - name: Blue
     file: catppuccin-accent-blue.scss
-
+  
   - name: Lavender
     file: catppuccin-accent-lavender.scss
+  

--- a/themes/ctp-latte/catppuccin-latte.scss
+++ b/themes/ctp-latte/catppuccin-latte.scss
@@ -511,7 +511,7 @@ body.body--light {
     background-color: var(--base);
     color: var(--text);
 
-    .close, [sfc-name='QItem'], .q-btn__content {
+    .close, [sfc-name='QItem'], [sfc-name='QBtn']:not(.bg-red, .bg-primary).q-btn__content {
       color: var(--text);
     }
 
@@ -867,6 +867,12 @@ body.body--light {
   /* Immersive Browser Toolbar */
   .im-toolbar {
     background: var(--base);
+  }
+
+  .im-window-controls {
+    .close {
+      color: var(--text);
+    }
   }
 
   .immersive-player {

--- a/themes/ctp-latte/catppuccin-latte.scss
+++ b/themes/ctp-latte/catppuccin-latte.scss
@@ -515,7 +515,7 @@ body.body--light {
     background-color: var(--base);
     color: var(--text);
 
-    .close {
+    .close, [sfc-name='QItem'], .q-btn__content {
       color: var(--text);
     }
 

--- a/themes/ctp-latte/catppuccin-latte.scss
+++ b/themes/ctp-latte/catppuccin-latte.scss
@@ -362,11 +362,7 @@ body.body--light {
       background: var(--selection-bg);
       color: var(--text);
 
-      .nav-icon {
-        color: var(--accent);
-      }
-
-      .nav-text {
+      .nav-icon, .nav-text {
         color: var(--accent);
       }
     }

--- a/themes/ctp-latte/catppuccin-latte.scss
+++ b/themes/ctp-latte/catppuccin-latte.scss
@@ -1011,5 +1011,9 @@ body.body--light {
       background-color: var(--mantle);
       color: var(--text);
     }
+
+    [sfc-name='QBadge'] {
+      color: var(--crust);
+    }
   }
 }

--- a/themes/ctp-latte/catppuccin-latte.scss
+++ b/themes/ctp-latte/catppuccin-latte.scss
@@ -38,7 +38,15 @@ body.body--light {
     background-color: var(--green);
   }
 
+  .bg-red {
+    background-color: var(--red);
+  }
+
   .text-default {
+    color: var(--text);
+  }
+
+  .text-white {
     color: var(--text);
   }
 
@@ -166,6 +174,17 @@ body.body--light {
     background: var(--crust);
   }
 
+  /* Input Box */
+  input[type='number'] {
+    color: var(--text);
+  }
+
+  /* Tooltips */
+  .q-tooltip {
+    background-color: var(--base);
+    color: var(--text);
+  }
+
   [sfc-name='HeaderSearch'] {
     .search-box {
       background: var(--mantle);
@@ -221,7 +240,7 @@ body.body--light {
         color: var(--text);
       }
 
-      .albumLink, .time {
+      .albumLink, .time, .trackNumber {
         color: var(--subtext1);
       }
 
@@ -355,6 +374,16 @@ body.body--light {
     .sidebar-label {
       opacity: 1;
     }
+
+    [sfc-name='QTabs'] {
+      background-color: var(--mantle);
+    }
+
+    [sfc-name='PageTabList'] {
+      .title-text {
+        color: var(--text);
+      }
+    }
   }
 
   /* Right Drawer / Queue / Lyrics */
@@ -462,6 +491,10 @@ body.body--light {
       }
     }
 
+    .q-btn.bg-primary, .q-btn.bg-primary [sfc-name='QIcon'] {
+      color: var(--crust);
+    }
+
     [sfc-name='QItemSection'] {
       color: var(--text);
 
@@ -560,6 +593,13 @@ body.body--light {
 
       [sfc-name='QCard'] {
         color: var(--text);
+      }
+
+      .themes-page {
+        [sfc-name='QList'] [sfc-name='QBtn'].q-btn--actionable {
+          background-color: transparent;
+          color: var(--text);
+        }
       }
     }
     /* Updates Window */
@@ -671,6 +711,25 @@ body.body--light {
 
     .am-audio-settings {
       background: var(--base);
+
+      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'] {
+        color: var(--text);
+      }
+
+      [sfc-name='AMEQ'] {
+        .mini, .close {
+          color: var(--text);
+        }
+
+        .eq-freq, .eq-q {
+          background-color: var(--mantle);
+          color: var(--text);
+        }
+
+        [sfc-name='QBtn'] {
+          color: var(--crust);
+        }
+      }
     }
   }
 
@@ -704,6 +763,19 @@ body.body--light {
 
     button .qb-item-content {
       color: var(--crust);
+    }
+  }
+
+  /* Multi Artist Picker */
+  .artist-picker-modal {
+    background-color: var(--base);
+
+    [sfc-name='QItemSection'], .modal-titlebar-content, .close {
+      color: var(--text);
+    }
+
+    .q-item-type+.q-item-type {
+      border-top-color: var(--surface0);
     }
   }
 

--- a/themes/ctp-latte/catppuccin-latte.scss
+++ b/themes/ctp-latte/catppuccin-latte.scss
@@ -181,7 +181,7 @@ body.body--light {
 
   /* Tooltips */
   .q-tooltip {
-    background-color: var(--base);
+    background-color: var(--mantle);
     color: var(--text);
   }
 
@@ -447,7 +447,7 @@ body.body--light {
     }
 
     [sfc-name='QTabs'] {
-      background: var(--base);
+      background-color: var(--base);
 
       .q-tab {
         color: var(--text);
@@ -458,7 +458,7 @@ body.body--light {
       }
 
       .q-tab__indicator {
-        background: var(--selection-bg);
+        background-color: var(--selection-bg);
       }
     }
   }
@@ -467,10 +467,10 @@ body.body--light {
 
   /* Menu & Pop-ups */
   .q-menu {
-    background: var(--base);
+    background-color: var(--mantle);
 
     .q-hoverable:hover {
-      background: var(--selection-bg);
+      background-color: var(--selection-bg);
     }
 
     [sfc-name='ContextMenuIcon'],
@@ -507,6 +507,37 @@ body.body--light {
       .overlay-progress-bar {
         background: var(--text);
       }
+    }
+  }
+
+  /* General Popups using QCard */
+  [role='dialog'] [sfc-name='QCard'] {
+    background-color: var(--base);
+    color: var(--text);
+
+    .close {
+      color: var(--text);
+    }
+
+    .q-field__control {
+      background: var(--crust);
+      border-color: var(--selection-bg);
+
+      .q-field__native {
+        color: var(--text);
+      }
+
+      .q-field__label {
+        color: var(--subtext1);
+      }
+    }
+
+    .q-field__counter {
+      color: var(--subtext1);
+    }
+
+    .q-btn.bg-primary, .q-btn.bg-primary [sfc-name='QIcon'] {
+      color: var(--crust);
     }
   }
 
@@ -598,7 +629,11 @@ body.body--light {
       .themes-page {
         [sfc-name='QList'] [sfc-name='QBtn'].q-btn--actionable {
           background-color: transparent;
-          color: var(--text);
+          color: var(--accent);
+        }
+
+        [sfc-name='QExpansionItem'] [sfc-name='QList'] {
+          background-color: var(--mantle);
         }
       }
     }
@@ -712,12 +747,12 @@ body.body--light {
     .am-audio-settings {
       background: var(--base);
 
-      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'] {
+      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'], .close {
         color: var(--text);
       }
 
       [sfc-name='AMEQ'] {
-        .mini, .close {
+        .mini {
           color: var(--text);
         }
 

--- a/themes/ctp-latte/theme.yml
+++ b/themes/ctp-latte/theme.yml
@@ -4,45 +4,46 @@ stylesheets:
   - name: Catppuccin Latte - Base
     file: catppuccin-latte.scss
     description: Enable your favorite accent below!
-
+  
   - name: Rosewater
     file: catppuccin-accent-rosewater.scss
-
+  
   - name: Flamingo
     file: catppuccin-accent-flamingo.scss
-
+  
   - name: Pink
     file: catppuccin-accent-pink.scss
-
+  
   - name: Mauve
     file: catppuccin-accent-mauve.scss
-
+  
   - name: Red
     file: catppuccin-accent-red.scss
-
+  
   - name: Maroon
     file: catppuccin-accent-maroon.scss
-
+  
   - name: Peach
     file: catppuccin-accent-peach.scss
-
+  
   - name: Yellow
     file: catppuccin-accent-yellow.scss
-
+  
   - name: Green
     file: catppuccin-accent-green.scss
-
+  
   - name: Teal
     file: catppuccin-accent-teal.scss
-
+  
   - name: Sky
     file: catppuccin-accent-sky.scss
-
+  
   - name: Sapphire
     file: catppuccin-accent-sapphire.scss
-
+  
   - name: Blue
     file: catppuccin-accent-blue.scss
-
+  
   - name: Lavender
     file: catppuccin-accent-lavender.scss
+  

--- a/themes/ctp-macchiato/catppuccin-macchiato.scss
+++ b/themes/ctp-macchiato/catppuccin-macchiato.scss
@@ -515,7 +515,7 @@ body.body--dark {
     background-color: var(--base);
     color: var(--text);
 
-    .close {
+    .close, [sfc-name='QItem'], .q-btn__content {
       color: var(--text);
     }
 

--- a/themes/ctp-macchiato/catppuccin-macchiato.scss
+++ b/themes/ctp-macchiato/catppuccin-macchiato.scss
@@ -362,11 +362,7 @@ body.body--dark {
       background: var(--selection-bg);
       color: var(--text);
 
-      .nav-icon {
-        color: var(--accent);
-      }
-
-      .nav-text {
+      .nav-icon, .nav-text {
         color: var(--accent);
       }
     }

--- a/themes/ctp-macchiato/catppuccin-macchiato.scss
+++ b/themes/ctp-macchiato/catppuccin-macchiato.scss
@@ -1011,5 +1011,9 @@ body.body--dark {
       background-color: var(--mantle);
       color: var(--text);
     }
+
+    [sfc-name='QBadge'] {
+      color: var(--crust);
+    }
   }
 }

--- a/themes/ctp-macchiato/catppuccin-macchiato.scss
+++ b/themes/ctp-macchiato/catppuccin-macchiato.scss
@@ -511,7 +511,7 @@ body.body--dark {
     background-color: var(--base);
     color: var(--text);
 
-    .close, [sfc-name='QItem'], .q-btn__content {
+    .close, [sfc-name='QItem'], [sfc-name='QBtn']:not(.bg-red, .bg-primary).q-btn__content {
       color: var(--text);
     }
 
@@ -867,6 +867,12 @@ body.body--dark {
   /* Immersive Browser Toolbar */
   .im-toolbar {
     background: var(--base);
+  }
+
+  .im-window-controls {
+    .close {
+      color: var(--text);
+    }
   }
 
   .immersive-player {

--- a/themes/ctp-macchiato/catppuccin-macchiato.scss
+++ b/themes/ctp-macchiato/catppuccin-macchiato.scss
@@ -38,7 +38,15 @@ body.body--dark {
     background-color: var(--green);
   }
 
+  .bg-red {
+    background-color: var(--red);
+  }
+
   .text-default {
+    color: var(--text);
+  }
+
+  .text-white {
     color: var(--text);
   }
 
@@ -166,6 +174,17 @@ body.body--dark {
     background: var(--crust);
   }
 
+  /* Input Box */
+  input[type='number'] {
+    color: var(--text);
+  }
+
+  /* Tooltips */
+  .q-tooltip {
+    background-color: var(--base);
+    color: var(--text);
+  }
+
   [sfc-name='HeaderSearch'] {
     .search-box {
       background: var(--mantle);
@@ -221,7 +240,7 @@ body.body--dark {
         color: var(--text);
       }
 
-      .albumLink, .time {
+      .albumLink, .time, .trackNumber {
         color: var(--subtext1);
       }
 
@@ -355,6 +374,16 @@ body.body--dark {
     .sidebar-label {
       opacity: 1;
     }
+
+    [sfc-name='QTabs'] {
+      background-color: var(--mantle);
+    }
+
+    [sfc-name='PageTabList'] {
+      .title-text {
+        color: var(--text);
+      }
+    }
   }
 
   /* Right Drawer / Queue / Lyrics */
@@ -462,6 +491,10 @@ body.body--dark {
       }
     }
 
+    .q-btn.bg-primary, .q-btn.bg-primary [sfc-name='QIcon'] {
+      color: var(--crust);
+    }
+
     [sfc-name='QItemSection'] {
       color: var(--text);
 
@@ -560,6 +593,13 @@ body.body--dark {
 
       [sfc-name='QCard'] {
         color: var(--text);
+      }
+
+      .themes-page {
+        [sfc-name='QList'] [sfc-name='QBtn'].q-btn--actionable {
+          background-color: transparent;
+          color: var(--text);
+        }
       }
     }
     /* Updates Window */
@@ -671,6 +711,25 @@ body.body--dark {
 
     .am-audio-settings {
       background: var(--base);
+
+      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'] {
+        color: var(--text);
+      }
+
+      [sfc-name='AMEQ'] {
+        .mini, .close {
+          color: var(--text);
+        }
+
+        .eq-freq, .eq-q {
+          background-color: var(--mantle);
+          color: var(--text);
+        }
+
+        [sfc-name='QBtn'] {
+          color: var(--crust);
+        }
+      }
     }
   }
 
@@ -704,6 +763,19 @@ body.body--dark {
 
     button .qb-item-content {
       color: var(--crust);
+    }
+  }
+
+  /* Multi Artist Picker */
+  .artist-picker-modal {
+    background-color: var(--base);
+
+    [sfc-name='QItemSection'], .modal-titlebar-content, .close {
+      color: var(--text);
+    }
+
+    .q-item-type+.q-item-type {
+      border-top-color: var(--surface0);
     }
   }
 

--- a/themes/ctp-macchiato/catppuccin-macchiato.scss
+++ b/themes/ctp-macchiato/catppuccin-macchiato.scss
@@ -181,7 +181,7 @@ body.body--dark {
 
   /* Tooltips */
   .q-tooltip {
-    background-color: var(--base);
+    background-color: var(--mantle);
     color: var(--text);
   }
 
@@ -447,7 +447,7 @@ body.body--dark {
     }
 
     [sfc-name='QTabs'] {
-      background: var(--base);
+      background-color: var(--base);
 
       .q-tab {
         color: var(--text);
@@ -458,7 +458,7 @@ body.body--dark {
       }
 
       .q-tab__indicator {
-        background: var(--selection-bg);
+        background-color: var(--selection-bg);
       }
     }
   }
@@ -467,10 +467,10 @@ body.body--dark {
 
   /* Menu & Pop-ups */
   .q-menu {
-    background: var(--base);
+    background-color: var(--mantle);
 
     .q-hoverable:hover {
-      background: var(--selection-bg);
+      background-color: var(--selection-bg);
     }
 
     [sfc-name='ContextMenuIcon'],
@@ -507,6 +507,37 @@ body.body--dark {
       .overlay-progress-bar {
         background: var(--text);
       }
+    }
+  }
+
+  /* General Popups using QCard */
+  [role='dialog'] [sfc-name='QCard'] {
+    background-color: var(--base);
+    color: var(--text);
+
+    .close {
+      color: var(--text);
+    }
+
+    .q-field__control {
+      background: var(--crust);
+      border-color: var(--selection-bg);
+
+      .q-field__native {
+        color: var(--text);
+      }
+
+      .q-field__label {
+        color: var(--subtext1);
+      }
+    }
+
+    .q-field__counter {
+      color: var(--subtext1);
+    }
+
+    .q-btn.bg-primary, .q-btn.bg-primary [sfc-name='QIcon'] {
+      color: var(--crust);
     }
   }
 
@@ -598,7 +629,11 @@ body.body--dark {
       .themes-page {
         [sfc-name='QList'] [sfc-name='QBtn'].q-btn--actionable {
           background-color: transparent;
-          color: var(--text);
+          color: var(--accent);
+        }
+
+        [sfc-name='QExpansionItem'] [sfc-name='QList'] {
+          background-color: var(--mantle);
         }
       }
     }
@@ -712,12 +747,12 @@ body.body--dark {
     .am-audio-settings {
       background: var(--base);
 
-      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'] {
+      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'], .close {
         color: var(--text);
       }
 
       [sfc-name='AMEQ'] {
-        .mini, .close {
+        .mini {
           color: var(--text);
         }
 

--- a/themes/ctp-macchiato/theme.yml
+++ b/themes/ctp-macchiato/theme.yml
@@ -4,45 +4,46 @@ stylesheets:
   - name: Catppuccin Macchiato - Base
     file: catppuccin-macchiato.scss
     description: Enable your favorite accent below!
-
+  
   - name: Rosewater
     file: catppuccin-accent-rosewater.scss
-
+  
   - name: Flamingo
     file: catppuccin-accent-flamingo.scss
-
+  
   - name: Pink
     file: catppuccin-accent-pink.scss
-
+  
   - name: Mauve
     file: catppuccin-accent-mauve.scss
-
+  
   - name: Red
     file: catppuccin-accent-red.scss
-
+  
   - name: Maroon
     file: catppuccin-accent-maroon.scss
-
+  
   - name: Peach
     file: catppuccin-accent-peach.scss
-
+  
   - name: Yellow
     file: catppuccin-accent-yellow.scss
-
+  
   - name: Green
     file: catppuccin-accent-green.scss
-
+  
   - name: Teal
     file: catppuccin-accent-teal.scss
-
+  
   - name: Sky
     file: catppuccin-accent-sky.scss
-
+  
   - name: Sapphire
     file: catppuccin-accent-sapphire.scss
-
+  
   - name: Blue
     file: catppuccin-accent-blue.scss
-
+  
   - name: Lavender
     file: catppuccin-accent-lavender.scss
+  

--- a/themes/ctp-mocha/catppuccin-mocha.scss
+++ b/themes/ctp-mocha/catppuccin-mocha.scss
@@ -515,7 +515,7 @@ body.body--dark {
     background-color: var(--base);
     color: var(--text);
 
-    .close {
+    .close, [sfc-name='QItem'], .q-btn__content {
       color: var(--text);
     }
 

--- a/themes/ctp-mocha/catppuccin-mocha.scss
+++ b/themes/ctp-mocha/catppuccin-mocha.scss
@@ -362,11 +362,7 @@ body.body--dark {
       background: var(--selection-bg);
       color: var(--text);
 
-      .nav-icon {
-        color: var(--accent);
-      }
-
-      .nav-text {
+      .nav-icon, .nav-text {
         color: var(--accent);
       }
     }

--- a/themes/ctp-mocha/catppuccin-mocha.scss
+++ b/themes/ctp-mocha/catppuccin-mocha.scss
@@ -1011,5 +1011,9 @@ body.body--dark {
       background-color: var(--mantle);
       color: var(--text);
     }
+
+    [sfc-name='QBadge'] {
+      color: var(--crust);
+    }
   }
 }

--- a/themes/ctp-mocha/catppuccin-mocha.scss
+++ b/themes/ctp-mocha/catppuccin-mocha.scss
@@ -511,7 +511,7 @@ body.body--dark {
     background-color: var(--base);
     color: var(--text);
 
-    .close, [sfc-name='QItem'], .q-btn__content {
+    .close, [sfc-name='QItem'], [sfc-name='QBtn']:not(.bg-red, .bg-primary).q-btn__content {
       color: var(--text);
     }
 
@@ -867,6 +867,12 @@ body.body--dark {
   /* Immersive Browser Toolbar */
   .im-toolbar {
     background: var(--base);
+  }
+
+  .im-window-controls {
+    .close {
+      color: var(--text);
+    }
   }
 
   .immersive-player {

--- a/themes/ctp-mocha/catppuccin-mocha.scss
+++ b/themes/ctp-mocha/catppuccin-mocha.scss
@@ -38,7 +38,15 @@ body.body--dark {
     background-color: var(--green);
   }
 
+  .bg-red {
+    background-color: var(--red);
+  }
+
   .text-default {
+    color: var(--text);
+  }
+
+  .text-white {
     color: var(--text);
   }
 
@@ -166,6 +174,17 @@ body.body--dark {
     background: var(--crust);
   }
 
+  /* Input Box */
+  input[type='number'] {
+    color: var(--text);
+  }
+
+  /* Tooltips */
+  .q-tooltip {
+    background-color: var(--base);
+    color: var(--text);
+  }
+
   [sfc-name='HeaderSearch'] {
     .search-box {
       background: var(--mantle);
@@ -221,7 +240,7 @@ body.body--dark {
         color: var(--text);
       }
 
-      .albumLink, .time {
+      .albumLink, .time, .trackNumber {
         color: var(--subtext1);
       }
 
@@ -355,6 +374,16 @@ body.body--dark {
     .sidebar-label {
       opacity: 1;
     }
+
+    [sfc-name='QTabs'] {
+      background-color: var(--mantle);
+    }
+
+    [sfc-name='PageTabList'] {
+      .title-text {
+        color: var(--text);
+      }
+    }
   }
 
   /* Right Drawer / Queue / Lyrics */
@@ -462,6 +491,10 @@ body.body--dark {
       }
     }
 
+    .q-btn.bg-primary, .q-btn.bg-primary [sfc-name='QIcon'] {
+      color: var(--crust);
+    }
+
     [sfc-name='QItemSection'] {
       color: var(--text);
 
@@ -560,6 +593,13 @@ body.body--dark {
 
       [sfc-name='QCard'] {
         color: var(--text);
+      }
+
+      .themes-page {
+        [sfc-name='QList'] [sfc-name='QBtn'].q-btn--actionable {
+          background-color: transparent;
+          color: var(--text);
+        }
       }
     }
     /* Updates Window */
@@ -671,6 +711,25 @@ body.body--dark {
 
     .am-audio-settings {
       background: var(--base);
+
+      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'] {
+        color: var(--text);
+      }
+
+      [sfc-name='AMEQ'] {
+        .mini, .close {
+          color: var(--text);
+        }
+
+        .eq-freq, .eq-q {
+          background-color: var(--mantle);
+          color: var(--text);
+        }
+
+        [sfc-name='QBtn'] {
+          color: var(--crust);
+        }
+      }
     }
   }
 
@@ -704,6 +763,19 @@ body.body--dark {
 
     button .qb-item-content {
       color: var(--crust);
+    }
+  }
+
+  /* Multi Artist Picker */
+  .artist-picker-modal {
+    background-color: var(--base);
+
+    [sfc-name='QItemSection'], .modal-titlebar-content, .close {
+      color: var(--text);
+    }
+
+    .q-item-type+.q-item-type {
+      border-top-color: var(--surface0);
     }
   }
 

--- a/themes/ctp-mocha/catppuccin-mocha.scss
+++ b/themes/ctp-mocha/catppuccin-mocha.scss
@@ -181,7 +181,7 @@ body.body--dark {
 
   /* Tooltips */
   .q-tooltip {
-    background-color: var(--base);
+    background-color: var(--mantle);
     color: var(--text);
   }
 
@@ -447,7 +447,7 @@ body.body--dark {
     }
 
     [sfc-name='QTabs'] {
-      background: var(--base);
+      background-color: var(--base);
 
       .q-tab {
         color: var(--text);
@@ -458,7 +458,7 @@ body.body--dark {
       }
 
       .q-tab__indicator {
-        background: var(--selection-bg);
+        background-color: var(--selection-bg);
       }
     }
   }
@@ -467,10 +467,10 @@ body.body--dark {
 
   /* Menu & Pop-ups */
   .q-menu {
-    background: var(--base);
+    background-color: var(--mantle);
 
     .q-hoverable:hover {
-      background: var(--selection-bg);
+      background-color: var(--selection-bg);
     }
 
     [sfc-name='ContextMenuIcon'],
@@ -507,6 +507,37 @@ body.body--dark {
       .overlay-progress-bar {
         background: var(--text);
       }
+    }
+  }
+
+  /* General Popups using QCard */
+  [role='dialog'] [sfc-name='QCard'] {
+    background-color: var(--base);
+    color: var(--text);
+
+    .close {
+      color: var(--text);
+    }
+
+    .q-field__control {
+      background: var(--crust);
+      border-color: var(--selection-bg);
+
+      .q-field__native {
+        color: var(--text);
+      }
+
+      .q-field__label {
+        color: var(--subtext1);
+      }
+    }
+
+    .q-field__counter {
+      color: var(--subtext1);
+    }
+
+    .q-btn.bg-primary, .q-btn.bg-primary [sfc-name='QIcon'] {
+      color: var(--crust);
     }
   }
 
@@ -598,7 +629,11 @@ body.body--dark {
       .themes-page {
         [sfc-name='QList'] [sfc-name='QBtn'].q-btn--actionable {
           background-color: transparent;
-          color: var(--text);
+          color: var(--accent);
+        }
+
+        [sfc-name='QExpansionItem'] [sfc-name='QList'] {
+          background-color: var(--mantle);
         }
       }
     }
@@ -712,12 +747,12 @@ body.body--dark {
     .am-audio-settings {
       background: var(--base);
 
-      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'] {
+      [sfc-name='QItemLabel'], [sfc-name='QTab'][aria-selected='false'], .close {
         color: var(--text);
       }
 
       [sfc-name='AMEQ'] {
-        .mini, .close {
+        .mini {
           color: var(--text);
         }
 

--- a/themes/ctp-mocha/theme.yml
+++ b/themes/ctp-mocha/theme.yml
@@ -4,45 +4,46 @@ stylesheets:
   - name: Catppuccin Mocha - Base
     file: catppuccin-mocha.scss
     description: Enable your favorite accent below!
-
+  
   - name: Rosewater
     file: catppuccin-accent-rosewater.scss
-
+  
   - name: Flamingo
     file: catppuccin-accent-flamingo.scss
-
+  
   - name: Pink
     file: catppuccin-accent-pink.scss
-
+  
   - name: Mauve
     file: catppuccin-accent-mauve.scss
-
+  
   - name: Red
     file: catppuccin-accent-red.scss
-
+  
   - name: Maroon
     file: catppuccin-accent-maroon.scss
-
+  
   - name: Peach
     file: catppuccin-accent-peach.scss
-
+  
   - name: Yellow
     file: catppuccin-accent-yellow.scss
-
+  
   - name: Green
     file: catppuccin-accent-green.scss
-
+  
   - name: Teal
     file: catppuccin-accent-teal.scss
-
+  
   - name: Sky
     file: catppuccin-accent-sky.scss
-
+  
   - name: Sapphire
     file: catppuccin-accent-sapphire.scss
-
+  
   - name: Blue
     file: catppuccin-accent-blue.scss
-
+  
   - name: Lavender
     file: catppuccin-accent-lavender.scss
+  


### PR DESCRIPTION
- Globally themes input number boxes, tooltips, `QCard`, and primary colored buttons.
- Track numbers in playlists
- Multi-artist modals
- Regression in CAL modal
- Adds theming to new page tabs
- Better contrast for dialogs/popups